### PR TITLE
feat(index.js): add support for fetching and parsing any specific CWE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fetch-cwe-list
 
-A simple Node.js module that fetches, extracts, and parses the latest Common Weakness Enumeration (CWE) list from MITRE, returning it as a convenient JavaScript array of objects. This package handles downloading, unzipping, and parsing the official CWE XML data for you.
+A simple Node.js module that fetches, extracts, and parses the latest **or a specific version** of the Common Weakness Enumeration (CWE) list from MITRE, returning it as a convenient JavaScript array of objects. This package handles downloading, unzipping, and parsing the official CWE XML data for you.
 
 ## Install
 
@@ -13,17 +13,23 @@ npm install fetch-cwe-list
 ```
 const fetchCweList = require('fetch-cwe-list')
 
+// Fetch the latest CWE list (default)
+const cweAry = await fetchCweList()
+
+// Fetch a specific CWE version (e.g., 4.16)
+const cweAry416 = await fetchCweList('4.16')
+
 // Promise usage
-fetchCweList().then((cweAry) => {
+fetchCweList('4.16').then((cweAry) => {
   console.log(cweAry)
 })
-
-// async/await usage
-const cweAry = await fetchCweList();
 ```
 
-- The result is an array of CWE objects, each representing a weakness entry from the latest MITRE CWE catalog.
+- The result is an array of CWE objects, each representing a weakness entry from the specified MITRE CWE catalog version.
 - All network, extraction, and parsing steps are handled automatically.
+- If no version is provided, the latest available CWE list is fetched.
+- **Version strings must match the MITRE format (e.g., `4.17`, `4.16`, `4.15`, ...).**
+- **See the [CWE Release Archive](https://cwe.mitre.org/data/archive.html) for all available version strings.**
 
 ## Example Output
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const unzipper = require('unzipper')
 const fs = require('fs')
 const { XMLParser } = require('fast-xml-parser')
 const path = require('path')
-const zipFileName = path.join(__dirname, 'output', 'cwec_latest.xml.zip')
 let externalReferenceAry = []
 const options = {
   ignoreAttributes: false,
@@ -14,8 +13,15 @@ const options = {
 
 // Download the CWE zip file and save it locally
 async function downloadCweZip (url, destPath) {
-  const response = await axios.get(url, { responseType: 'arraybuffer' })
-  await fs.promises.writeFile(destPath, response.data)
+  try {
+    const response = await axios.get(url, { responseType: 'arraybuffer' })
+    await fs.promises.writeFile(destPath, response.data)
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      throw new Error(`CWE version not found at ${url} (status: 404)`)
+    }
+    throw err
+  }
 }
 
 // Extract all XML files from the zip and return their buffers
@@ -24,11 +30,11 @@ async function extractXmlBuffersFromZip (zipPath) {
   await new Promise((resolve, reject) => {
     fs.createReadStream(zipPath)
       .pipe(unzipper.Parse())
-      .on('entry', function (entry) {
+      .on('entry', (entry) => {
         const fileName = entry.path
         if (fileName.endsWith('.xml')) {
           const chunks = []
-          entry.on('data', chunk => chunks.push(chunk))
+          entry.on('data', (chunk) => chunks.push(chunk))
           entry.on('end', () => xmlBuffers.push(Buffer.concat(chunks)))
           entry.on('error', reject)
         } else {
@@ -44,7 +50,6 @@ async function extractXmlBuffersFromZip (zipPath) {
 // Parse XML buffer to JSON using fast-xml-parser
 function parseXmlBufferToJson (xmlBuffer, options) {
   const xmlPreview = xmlBuffer.toString('utf8', 0, 200)
-  console.log('XML file preview:', xmlPreview)
   if (!xmlPreview.trim().startsWith('<?xml')) {
     throw new Error('Extracted file does not appear to be valid XML.')
   }
@@ -61,35 +66,49 @@ function cleanupFile (filePath) {
   }
 }
 
-const fetchCwecLatest = () => {
-  return new Promise((resolve, reject) => {
-    (async () => {
-      try {
-        const url = 'https://cwe.mitre.org/data/xml/cwec_latest.xml.zip'
-        await downloadCweZip(url, zipFileName)
-        const xmlBuffers = await extractXmlBuffersFromZip(zipFileName)
-        if (xmlBuffers.length === 0) return reject(new Error('No XML files found in the zip.'))
-        const data = Buffer.concat(xmlBuffers)
-        let cweParsed
-        try {
-          cweParsed = parseXmlBufferToJson(data, options)
-        } catch (err) {
-          return reject(err)
-        }
-        const cweWeaknessAry = cweParsed.Weakness_Catalog.Weaknesses.Weakness.map((x) => x)
-        externalReferenceAry = cweParsed.Weakness_Catalog.External_References.External_Reference
-        cleanupFile(zipFileName)
-        resolve(cweWeaknessAry)
-      } catch (error) {
-        console.error(error)
-        reject(error)
-      }
-    })()
-  })
+// Helper to construct the correct URL and zip path for a given version
+function getCweZipUrlAndPath (version) {
+  let url, zipPath
+  if (!version || version === 'latest') {
+    url = 'https://cwe.mitre.org/data/xml/cwec_latest.xml.zip'
+    zipPath = path.join(__dirname, 'output', 'cwec_latest.xml.zip')
+  } else {
+    // Validate version string (e.g., "4.16")
+    // Only allow digits and dots, and must match the MITRE version format
+    if (!/^\d+(\.\d+)*$/.test(version)) {
+      throw new Error('Invalid version format. Use, for example, "4.16" or "latest".')
+    }
+    // Prevent path traversal by rejecting any version with '..' or '/'
+    if (version.includes('..') || version.includes('/') || version.includes('\\')) {
+      throw new Error('Invalid version: path traversal is not allowed.')
+    }
+    url = `https://cwe.mitre.org/data/xml/cwec_v${version}.xml.zip`
+    zipPath = path.join(__dirname, 'output', `cwec_v${version}.xml.zip`)
+  }
+  return { url, zipPath }
+}
+
+// Fetch and parse CWE catalog for a given version (or latest)
+async function fetchCwec (version) {
+  const { url, zipPath } = getCweZipUrlAndPath(version)
+  try {
+    await downloadCweZip(url, zipPath)
+    const xmlBuffers = await extractXmlBuffersFromZip(zipPath)
+    if (xmlBuffers.length === 0) throw new Error('No XML files found in the zip.')
+    const data = Buffer.concat(xmlBuffers)
+    const cweParsed = parseXmlBufferToJson(data, options)
+    const cweWeaknessAry = cweParsed.Weakness_Catalog.Weaknesses.Weakness.map((x) => x)
+    externalReferenceAry = cweParsed.Weakness_Catalog.External_References.External_Reference
+    cleanupFile(zipPath)
+    return cweWeaknessAry
+  } catch (error) {
+    cleanupFile(zipPath)
+    throw error
+  }
 }
 
 const getExternalReferencesByCwe = (cwe) => {
-  if (Array.isArray(cwe.References.Reference)) {
+  if (Array.isArray(cwe.References?.Reference)) {
     cwe.References.Full_Details = []
     for (const externalReferenceId of cwe.References.Reference) {
       const fullReferenceDetails = externalReferenceAry.find(
@@ -100,20 +119,22 @@ const getExternalReferencesByCwe = (cwe) => {
   }
 }
 
-// TODO add optional parameters for deleting items and where to store them
-const fetchCweList = async () => {
-  const cweWeaknessAry = await fetchCwecLatest()
+// Main API: fetchCweList([version])
+const fetchCweList = async (version) => {
+  const cweWeaknessAry = await fetchCwec(version)
   for (const cwe of cweWeaknessAry) {
     if (cwe.References) getExternalReferencesByCwe(cwe)
   }
-  // Cleanup is handled in fetchCwecLatest
   return cweWeaknessAry
 }
 
 module.exports = fetchCweList
 
+// CLI usage
 if (require.main === module) {
-  fetchCweList().then((list) => {
+  // Accept version as optional CLI argument
+  const version = process.argv[2] || 'latest'
+  fetchCweList(version).then((list) => {
     console.log(`Fetched ${list.length} CWE entries.`)
     // Optionally print a sample entry
     console.log(JSON.stringify(list[0], null, 2))


### PR DESCRIPTION
… version from the MITRE archive

Support for fetching and parsing any specific CWE version from the official MITRE archive is now included. By providing a version string (such as "4.16"), the module securely downloads, extracts, and parses the corresponding release, enabling access to historical CWE data for research or compliance. Strict input validation ensures only valid version strings are accepted.