### PR TITLE
ci: add guppy-agent security scanning workflow

### DIFF
--- a/.github/workflows/guppy-scan.yml
+++ b/.github/workflows/guppy-scan.yml
@@ -1,0 +1,30 @@
+name: Guppy Security Scan
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  guppy-scan:
+    runs-on: ubuntu-latest
+    name: Security Scan
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Guppy Security Scanner
+        uses: alejandrosaenz117/guppy-agent@1d4b5b6c4d121445ccc5a6dab52389084081cb2c
+        with:
+          provider: anthropic
+          model: claude-sonnet-4-6
+          fail_on_severity: high
+          sca_enabled: true
+          post_comments: true
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/guppy-scan.yml
+++ b/.github/workflows/guppy-scan.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Guppy Security Scanner
-        uses: alejandrosaenz117/guppy-agent@1d4b5b6c4d121445ccc5a6dab52389084081cb2c
+        uses: alejandrosaenz117/guppy-agent@cac76b41208c869f223062edc47a8d3d63b0edb1
         with:
           provider: anthropic
           model: claude-sonnet-4-6

--- a/.github/workflows/guppy-scan.yml
+++ b/.github/workflows/guppy-scan.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Guppy Security Scanner
-        uses: alejandrosaenz117/guppy-agent@cac76b41208c869f223062edc47a8d3d63b0edb1
+        uses: alejandrosaenz117/guppy-agent@fc98337bc227bff026b52886fafbbbd973c2dff2
         with:
           provider: anthropic
           model: claude-sonnet-4-6


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to automatically scan all pull requests for security vulnerabilities using guppy-agent.

## Configuration

- **Provider:** Anthropic Claude Sonnet 4.6
- **Severity Threshold:** HIGH (blocks merge on high findings)
- **SCA:** Enabled (scans dependency lockfiles)
- **Inline Comments:** Enabled (posts findings on affected PR lines)
- **Secrets:** Passed via environment variables (`LLM_API_KEY`, `GITHUB_TOKEN`)
- **Pin:** Action pinned to immutable commit SHA `1d4b5b6c...` (v1.8.10)
- **Permissions:** Minimal — `contents:read`, `pull-requests:write` only

## Setup

Ensure `LLM_API_KEY` secret is configured in GitHub repository settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)